### PR TITLE
Change how  --no-acking works 

### DIFF
--- a/cmd/consume.go
+++ b/cmd/consume.go
@@ -104,7 +104,7 @@ Use comma-separated values for binding the same queue with multiple routing keys
 		msgs, err := ch.Consume(
 			queue,     // queue
 			"",        // consumer id
-			!noAck,    // auto-ack
+			false,    // auto-ack
 			exclusive, // exclusive
 			false,     // no-local
 			false,     // no-wait
@@ -131,6 +131,10 @@ Use comma-separated values for binding the same queue with multiple routing keys
 					if val, err := reflections.GetField(msg, key); err == nil && val != reflect.Zero(reflect.TypeOf(val)).Interface() {
 						fmt.Printf("%s: %q\n", key, val)
 					}
+				}
+
+				if !noAck {
+					ch.Ack(msg.DeliveryTag, false)
 				}
 
 				count++

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/hassansin/amqptools/cmd"
+import "github.com/marcinkoziej/amqptools/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Hi!
I wanted to use `amqp consume -n 1` to just get one message and exit.
But I couldn't:

The auto-acking option set in _amqp channel consume_ call would mean, that if there were more messages waiting, we would still get more then one message (even with prefetch =1).
I tried with --no-ack but then the actions would not be removed from the queue at all (because server would not receive any acks).

I changed the way --no-ack works - we always do auto-ack = false, and then we ack or not depending on the --no-ack flag.
Please check if this works also for your use case.
